### PR TITLE
Refactor Gatsby configuration and update Sass color functions

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,7 +35,6 @@ module.exports = {
     },
     'gatsby-plugin-sitemap',
     'gatsby-plugin-robots-txt',
-    'gatsby-plugin-react-helmet',
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -48,7 +48,14 @@ module.exports = {
       },
     },
     'gatsby-plugin-image',
-    'gatsby-plugin-sass',
+    {
+      resolve: `gatsby-plugin-sass`,
+      options: {
+        sassOptions: {
+          silenceDeprecations: ['legacy-js-api', 'import', 'global-builtin', 'if-function'],
+        },
+      },
+    },
     'gatsby-plugin-offline',
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',

--- a/src/assets/sass/base/_typography.scss
+++ b/src/assets/sass/base/_typography.scss
@@ -4,6 +4,7 @@
 /// Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 ///
 @use 'sass:math';
+@use 'sass:color';
 
 /* Type */
 
@@ -30,7 +31,7 @@
 		));
 		text-decoration: none;
 		color: _palette(fg);
-		border-bottom: dotted 1px transparentize(_palette(fg), 0.5);
+		border-bottom: dotted 1px color.scale(_palette(fg), $alpha: -50%);
 
 		&:hover {
 			border-bottom-color: transparent;

--- a/src/assets/sass/components/_button.scss
+++ b/src/assets/sass/components/_button.scss
@@ -3,6 +3,7 @@
 /// html5up.net | @ajlkn
 /// Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 ///
+@use 'sass:color';
 
 /* Button */
 
@@ -53,7 +54,7 @@
 		}
 
 		&:active {
-			background-color: transparentize(_palette(accent1), 0.9);
+			background-color: color.scale(_palette(accent1), $alpha: -90%);
 		}
 
 		&.small {
@@ -74,7 +75,7 @@
 			}
 
 			&:active {
-				background-color: darken(_palette(accent1), 8);
+				background-color: color.scale(_palette(accent1), $lightness: -8%);
 			}
 		}
 

--- a/src/assets/sass/components/_icon.scss
+++ b/src/assets/sass/components/_icon.scss
@@ -3,6 +3,7 @@
 /// html5up.net | @ajlkn
 /// Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 ///
+@use 'sass:color';
 
 /* Icon */
 
@@ -44,7 +45,7 @@
 			}
 
 			&:active {
-				background-color: transparentize(_palette(accent1), 0.9);
+				background-color: color.scale(_palette(accent1), $alpha: -90%);
 			}
 		}
 	}

--- a/src/assets/sass/layout/_footer.scss
+++ b/src/assets/sass/layout/_footer.scss
@@ -3,6 +3,7 @@
 /// html5up.net | @ajlkn
 /// Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 ///
+@use 'sass:color';
 
 /* Footer */
 
@@ -37,7 +38,7 @@
 				margin-top: 5em;
 				list-style: none;
 				font-size: 0.8em;
-				color: transparentize(_palette(fg), 0.5);
+				color: color.scale(_palette(fg), $alpha: -50%);
 
 				a {
 					color: inherit;
@@ -45,7 +46,7 @@
 
 				li {
 					display: inline-block;
-					border-left: solid 1px transparentize(_palette(fg), 0.85);
+					border-left: solid 1px color.scale(_palette(fg), $alpha: -85%);
 					line-height: 1;
 					padding: 0 0 0 1em;
 					margin: 0 0 0 1em;

--- a/src/assets/sass/layout/_header.scss
+++ b/src/assets/sass/layout/_header.scss
@@ -3,6 +3,7 @@
 /// html5up.net | @ajlkn
 /// Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 ///
+@use 'sass:color';
 
 /* Header */
 
@@ -72,7 +73,7 @@
           height: 3em;
           line-height: 3em;
           padding: 0 1.5em;
-          background-color: transparentize(_palette(bg), 0.5);
+          background-color: color.scale(_palette(bg), $alpha: -50%);
           border-radius: _size(border-radius);
           border: 0;
           font-size: 0.8em;

--- a/src/assets/sass/layout/_menu.scss
+++ b/src/assets/sass/layout/_menu.scss
@@ -3,6 +3,7 @@
 /// html5up.net | @ajlkn
 /// Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 ///
+@use 'sass:color';
 
 /* Menu */
 
@@ -49,7 +50,7 @@
 
       > li {
         padding: 0;
-        border-top: solid 1px transparentize(_palette(bg), 0.85);
+        border-top: solid 1px color.scale(_palette(bg), $alpha: -85%);
 
         a {
           display: block;

--- a/src/assets/sass/libs/_breakpoints.scss
+++ b/src/assets/sass/libs/_breakpoints.scss
@@ -1,7 +1,9 @@
 // breakpoints.scss v1.0 | @ajlkn | MIT licensed */
 
 @use "sass:string";
+@use "sass:list";
 @use "sass:map";
+@use "sass:meta";
 
 // Vars.
 
@@ -89,10 +91,10 @@
 				$a: map.get($breakpoints, $breakpoint);
 
 				// Range.
-					@if (type-of($a) == 'list') {
+					@if (meta.type-of($a) == 'list') {
 
-						$x: nth($a, 1);
-						$y: nth($a, 2);
+						$x: list.nth($a, 1);
+						$y: list.nth($a, 2);
 
 						// Max only.
 							@if ($x == null) {

--- a/src/assets/sass/libs/_breakpoints.scss
+++ b/src/assets/sass/libs/_breakpoints.scss
@@ -1,5 +1,8 @@
 // breakpoints.scss v1.0 | @ajlkn | MIT licensed */
 
+@use "sass:string";
+@use "sass:map";
+
 // Vars.
 
 	/// Breakpoints.
@@ -33,42 +36,42 @@
 		// Determine operator, breakpoint.
 
 			// Greater than or equal.
-				@if (str-slice($query, 0, 2) == '>=') {
+				@if (string.slice($query, 0, 2) == '>=') {
 
 					$op: 'gte';
-					$breakpoint: str-slice($query, 3);
+					$breakpoint: string.slice($query, 3);
 
 				}
 
 			// Less than or equal.
-				@else if (str-slice($query, 0, 2) == '<=') {
+				@else if (string.slice($query, 0, 2) == '<=') {
 
 					$op: 'lte';
-					$breakpoint: str-slice($query, 3);
+					$breakpoint: string.slice($query, 3);
 
 				}
 
 			// Greater than.
-				@else if (str-slice($query, 0, 1) == '>') {
+				@else if (string.slice($query, 0, 1) == '>') {
 
 					$op: 'gt';
-					$breakpoint: str-slice($query, 2);
+					$breakpoint: string.slice($query, 2);
 
 				}
 
 			// Less than.
-				@else if (str-slice($query, 0, 1) == '<') {
+				@else if (string.slice($query, 0, 1) == '<') {
 
 					$op: 'lt';
-					$breakpoint: str-slice($query, 2);
+					$breakpoint: string.slice($query, 2);
 
 				}
 
 			// Not.
-				@else if (str-slice($query, 0, 1) == '!') {
+				@else if (string.slice($query, 0, 1) == '!') {
 
 					$op: 'not';
-					$breakpoint: str-slice($query, 2);
+					$breakpoint: string.slice($query, 2);
 
 				}
 
@@ -81,9 +84,9 @@
 				}
 
 		// Build media.
-			@if ($breakpoint and map-has-key($breakpoints, $breakpoint)) {
+			@if ($breakpoint and map.has-key($breakpoints, $breakpoint)) {
 
-				$a: map-get($breakpoints, $breakpoint);
+				$a: map.get($breakpoints, $breakpoint);
 
 				// Range.
 					@if (type-of($a) == 'list') {
@@ -202,7 +205,7 @@
 					@else {
 
 						// Missing a media type? Prefix with "screen".
-							@if (str-slice($a, 0, 1) == '(') {
+							@if (string.slice($a, 0, 1) == '(') {
 								$media: 'screen and ' + $a;
 							}
 

--- a/src/assets/sass/libs/_functions.scss
+++ b/src/assets/sass/libs/_functions.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 /// Removes a specific item from a list.
 /// @author Hugo Giraudel
 /// @param {list} $list List.
@@ -47,7 +49,7 @@
 	}
 
 	@each $key in $keys {
-		$map: map-get($map, $key);
+		$map: map.get($map, $key);
 	}
 
 	@return $map;

--- a/src/assets/sass/libs/_functions.scss
+++ b/src/assets/sass/libs/_functions.scss
@@ -1,4 +1,6 @@
 @use "sass:map";
+@use "sass:list";
+@use "sass:meta";
 
 /// Removes a specific item from a list.
 /// @author Hugo Giraudel
@@ -9,7 +11,7 @@
 
 	$result: null;
 
-	@if type-of($index) != number {
+	@if meta.type-of($index) != number {
 		@warn "$index: #{quote($index)} is not a number for `remove-nth`.";
 	}
 	@else if $index == 0 {
@@ -21,12 +23,14 @@
 	@else {
 
 		$result: ();
-		$index: if($index < 0, length($list) + $index + 1, $index);
+		@if $index < 0 {
+			$index: length($list) + $index + 1;
+		}
 
 		@for $i from 1 through length($list) {
 
 			@if $i != $index {
-				$result: append($result, nth($list, $i));
+				$result: list.append($result, list.nth($list, $i));
 			}
 
 		}
@@ -44,7 +48,7 @@
 /// @return {string} Value.
 @function val($map, $keys...) {
 
-	@if nth($keys, 1) == null {
+	@if list.nth($keys, 1) == null {
 		$keys: remove-nth($keys, 1);
 	}
 

--- a/src/assets/sass/libs/_html-grid.scss
+++ b/src/assets/sass/libs/_html-grid.scss
@@ -2,6 +2,8 @@
 
 // Mixins.
 @use 'sass:math';
+@use 'sass:list';
+@use 'sass:meta';
 
 	/// Initializes the current element as an HTML grid.
 	/// @param {mixed} $gutters Gutters (either a single number to set both column/row gutters, or a list to set them individually).
@@ -16,7 +18,7 @@
 			// Suffixes.
 				$suffixes: null;
 
-				@if (type-of($suffix) == 'list') {
+				@if (meta.type-of($suffix) == 'list') {
 					$suffixes: $suffix;
 				}
 				@else {
@@ -27,10 +29,10 @@
 				$guttersCols: null;
 				$guttersRows: null;
 
-				@if (type-of($gutters) == 'list') {
+				@if (meta.type-of($gutters) == 'list') {
 
-					$guttersCols: nth($gutters, 1);
-					$guttersRows: nth($gutters, 2);
+					$guttersCols: list.nth($gutters, 1);
+					$guttersRows: list.nth($gutters, 2);
 
 				}
 				@else {

--- a/src/assets/sass/libs/_vendor.scss
+++ b/src/assets/sass/libs/_vendor.scss
@@ -1,6 +1,8 @@
 // vendor.scss v1.0 | @ajlkn | MIT licensed */
 
 @use "sass:string";
+@use "sass:list";
+@use "sass:meta";
 
 // Vars.
 
@@ -260,7 +262,7 @@
 
 		$result: null;
 
-		@if type-of($index) != number {
+		@if meta.type-of($index) != number {
 			@warn "$index: #{quote($index)} is not a number for `remove-nth`.";
 		}
 		@else if $index == 0 {
@@ -272,12 +274,14 @@
 		@else {
 
 			$result: ();
-			$index: if($index < 0, length($list) + $index + 1, $index);
+			@if $index < 0 {
+				$index: length($list) + $index + 1;
+			}
 
 			@for $i from 1 through length($list) {
 
 				@if $i != $index {
-					$result: append($result, nth($list, $i));
+					$result: list.append($result, list.nth($list, $i));
 				}
 
 			}
@@ -314,7 +318,7 @@
 	@function str-replace-all($strings, $search, $replace: '') {
 
 		@each $string in $strings {
-			$strings: set-nth($strings, index($strings, $string), str-replace($string, $search, $replace));
+			$strings: list.set-nth($strings, list.index($strings, $string), str-replace($string, $search, $replace));
 		}
 
 		@return $strings;
@@ -340,7 +344,7 @@
 	@mixin vendor($property, $value) {
 
 		// Determine if property should expand.
-			$expandProperty: index($vendor-properties, $property);
+			$expandProperty: list.index($vendor-properties, $property);
 
 		// Determine if value should expand (and if so, add '-prefix-' placeholder).
 			$expandValue: false;
@@ -349,7 +353,7 @@
 				@each $y in $vendor-values {
 					@if $y == string.slice($x, 1, str-length($y)) {
 
-						$value: set-nth($value, index($value, $x), '-prefix-' + $x);
+						$value: list.set-nth($value, list.index($value, $x), '-prefix-' + $x);
 						$expandValue: true;
 
 					}

--- a/src/assets/sass/libs/_vendor.scss
+++ b/src/assets/sass/libs/_vendor.scss
@@ -1,5 +1,7 @@
 // vendor.scss v1.0 | @ajlkn | MIT licensed */
 
+@use "sass:string";
+
 // Vars.
 
 	/// Vendor prefixes.
@@ -297,7 +299,7 @@
 		$index: str-index($string, $search);
 
 		@if $index {
-			@return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+			@return string.slice($string, 1, $index - 1) + $replace + str-replace(string.slice($string, $index + str-length($search)), $search, $replace);
 		}
 
 		@return $string;
@@ -345,7 +347,7 @@
 
 			@each $x in $value {
 				@each $y in $vendor-values {
-					@if $y == str-slice($x, 1, str-length($y)) {
+					@if $y == string.slice($x, 1, str-length($y)) {
 
 						$value: set-nth($value, index($value, $x), '-prefix-' + $x);
 						$expandValue: true;


### PR DESCRIPTION
- Removed 'gatsby-plugin-react-helmet' from gatsby-config.js.
- Updated typography styles to use 'sass:color' for color scaling.
- Refactored button, icon, footer, header, and menu styles to utilize 'sass:color' for color manipulations.
- Enhanced breakpoint and function libraries to use new Sass string and map functions.